### PR TITLE
Add Farmland tag

### DIFF
--- a/src/main/java/net/gudenau/minecraft/moretags/MoreTags.java
+++ b/src/main/java/net/gudenau/minecraft/moretags/MoreTags.java
@@ -1,6 +1,5 @@
 package net.gudenau.minecraft.moretags;
 
-import java.util.stream.Stream;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.tag.TagRegistry;
 import net.minecraft.block.Block;
@@ -9,8 +8,9 @@ import net.minecraft.util.Identifier;
 
 public final class MoreTags implements ModInitializer{
     public static final String MOD_ID = "moretags";
-    
+
     public static final Tag<Block> BOOKSHELVES = TagRegistry.block(new Identifier(MOD_ID, "bookshelves"));
+    public static final Tag<Block> FARMLAND = TagRegistry.block(new Identifier(MOD_ID, "farmland"));
     public static final Tag<Block> ORES = TagRegistry.block(new Identifier(MOD_ID, "ores"));
     public static final Tag<Block> STRIPPED_WOOD = TagRegistry.block(new Identifier(MOD_ID, "stripped_wood"));
     public static final Tag<Block> STRIPPED_LOGS = TagRegistry.block(new Identifier(MOD_ID, "stripped_logs"));

--- a/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/CropBlockMixin.java
+++ b/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/CropBlockMixin.java
@@ -1,0 +1,47 @@
+package net.gudenau.minecraft.moretags.mixins.farmland;
+
+import net.gudenau.minecraft.moretags.MoreTags;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CropBlock;
+import net.minecraft.block.FarmlandBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CropBlock.class)
+public class CropBlockMixin {
+    @Inject(method = "getAvailableMoisture", at = @At("RETURN"), cancellable = true)
+    private static void getCropGrowthSpeed(Block block, BlockView view, BlockPos pos, CallbackInfoReturnable<Float> ci) {
+        float newSpeed = ci.getReturnValue();
+        BlockPos blockPos_2 = pos.down();
+
+        for (int rangeX = -1; rangeX <= 1; ++rangeX) {
+            for (int rangeZ = -1; rangeZ <= 1; ++rangeZ) {
+                float extraSpeed = 0.0F;
+                BlockState blockState_1 = view.getBlockState(blockPos_2.add(rangeX, 0, rangeZ));
+
+                if (MoreTags.FARMLAND.contains(blockState_1.getBlock())) {
+                    extraSpeed = 3.0F;
+
+                    if (blockState_1.getProperties().contains(FarmlandBlock.MOISTURE) && !(blockState_1.get(FarmlandBlock.MOISTURE) > 0)) {
+                        extraSpeed = 1.0F;
+                    }
+                }
+                if (rangeX != 0 || rangeZ != 0) extraSpeed /= 4.0F;
+                newSpeed += extraSpeed;
+            }
+        }
+        ci.setReturnValue(newSpeed);
+    }
+
+    @Inject(method = "canPlantOnTop", at = @At("TAIL"), cancellable = true)
+    protected void canPlantOnTop(BlockState floor, BlockView world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(
+                cir.getReturnValue() || MoreTags.FARMLAND.contains(floor.getBlock())
+        );
+    }
+}

--- a/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/EatCarrotCropGoalMixin.java
+++ b/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/EatCarrotCropGoalMixin.java
@@ -1,0 +1,16 @@
+package net.gudenau.minecraft.moretags.mixins.farmland;
+
+import net.gudenau.minecraft.moretags.MoreTags;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(targets = "net/minecraft/entity/passive/RabbitEntity$EatCarrotCropGoal")
+public abstract class EatCarrotCropGoalMixin {
+    @Redirect(method = "isTargetPos(Lnet/minecraft/world/WorldView;Lnet/minecraft/util/math/BlockPos;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z"))
+    public boolean isThisOrAetherFarmland(BlockState self, Block block) {
+        return self.isOf(block) || MoreTags.FARMLAND.contains(self.getBlock());
+    }
+}

--- a/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/PlantBlockMixin.java
+++ b/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/PlantBlockMixin.java
@@ -1,0 +1,20 @@
+package net.gudenau.minecraft.moretags.mixins.farmland;
+
+import net.gudenau.minecraft.moretags.MoreTags;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.PlantBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlantBlock.class)
+public class PlantBlockMixin {
+    @Inject(method = "canPlantOnTop", at = @At("TAIL"), cancellable = true)
+    protected void canPlantOnTop(BlockState floor, BlockView world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        // @reason Farmland is hardcoded in source code...
+        cir.setReturnValue(cir.getReturnValue() || MoreTags.FARMLAND.contains(floor.getBlock()));
+    }
+}

--- a/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/VillagerProfessionMixin.java
+++ b/src/main/java/net/gudenau/minecraft/moretags/mixins/farmland/VillagerProfessionMixin.java
@@ -1,0 +1,29 @@
+package net.gudenau.minecraft.moretags.mixins.farmland;
+
+import com.google.common.collect.ImmutableSet;
+import net.gudenau.minecraft.moretags.MoreTags;
+import net.minecraft.block.Block;
+import net.minecraft.village.VillagerProfession;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(VillagerProfession.class)
+public abstract class VillagerProfessionMixin {
+    @Shadow
+    @Mutable
+    @Final
+    private ImmutableSet<Block> secondaryJobSites;
+
+    @Shadow
+    @Final
+    public static VillagerProfession FARMER;
+
+    static {
+        ((VillagerProfessionMixin) (Object) FARMER).secondaryJobSites = ImmutableSet.<Block>builder()
+                .addAll(((VillagerProfessionMixin) (Object) FARMER).secondaryJobSites)
+                .addAll(MoreTags.FARMLAND.values())
+                .build();
+    }
+}

--- a/src/main/resources/data/moretags/tags/blocks/farmland.json
+++ b/src/main/resources/data/moretags/tags/blocks/farmland.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:farmland"
+  ]
+}

--- a/src/main/resources/moretags.mixins.json
+++ b/src/main/resources/moretags.mixins.json
@@ -6,6 +6,10 @@
   "mixins": [
     "bookshelves.EnchantingTableBlockMixin",
     "bookshelves.EnchantmentScreenHandlerMixin",
+    "farmland.CropBlockMixin",
+    "farmland.EatCarrotCropGoalMixin",
+    "farmland.PlantBlockMixin",
+    "farmland.VillagerProfessionMixin",
     "stickyblocks.PistonHandlerMixin"
   ],
   "client": [


### PR DESCRIPTION
These changes let mods create their own farmland blocks without needing their own mixins. Their farmland blocks will still need to extend FarmlandBlock of course, but this takes care of the rest. (If they don't extend farmland blocks, the only differences are that villagers won't work at them and it will be assumed that the block is moist).