### PR TITLE
Fix typo that breaks shears from working

### DIFF
--- a/src/main/resources/data/c/tags/items/shears.json
+++ b/src/main/resources/data/c/tags/items/shears.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "minecraft:shear"
+    "minecraft:shears"
   ]
 }


### PR DESCRIPTION
The default shears tag has a typo, preventing the tag from loading, and breaking shears from working